### PR TITLE
数学関数と行列操作の追加

### DIFF
--- a/MT4.vcxproj
+++ b/MT4.vcxproj
@@ -61,7 +61,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>C:\KamataEngine\Adapter;C:\KamataEngine\External\imgui;C:\KamataEngine\External\KamataEngine\include;C:\KamataEngine\External\DirectXTex\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\KamataEngine\Adapter;C:\KamataEngine\External\imgui;C:\KamataEngine\External\KamataEngine\include;C:\KamataEngine\External\DirectXTex\include;%(AdditionalIncludeDirectories);$(ProjectDir)math;$(ProjectDir)math/structure</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -86,7 +86,7 @@ xcopy C:\KamataEngine\DirectXGame\Resources "$(OutDirFullPath)NoviceResources" /
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>C:\KamataEngine\Adapter;C:\KamataEngine\External\KamataEngine\include;C:\KamataEngine\External\DirectXTex\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\KamataEngine\Adapter;C:\KamataEngine\External\KamataEngine\include;C:\KamataEngine\External\DirectXTex\include;%(AdditionalIncludeDirectories);$(ProjectDir)math;$(ProjectDir)math/structure</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <Optimization>MinSpace</Optimization>
       <LanguageStandard>stdcpp20</LanguageStandard>
@@ -139,6 +139,15 @@ xcopy C:\KamataEngine\DirectXGame\Resources "$(OutDirFullPath)NoviceResources" /
     <ClInclude Include="C:\KamataEngine\DirectXGame\input\Input.h" />
     <ClInclude Include="C:\KamataEngine\DirectXGame\scene\GameScene.h" />
     <ClInclude Include="C:\KamataEngine\Adapter\Novice.h" />
+    <ClInclude Include="math\AffineTransformations.h" />
+    <ClInclude Include="math\MathFunc4x4.h" />
+    <ClInclude Include="math\RenderingMatrices.h" />
+    <ClInclude Include="math\structure\Matrix3x3.h" />
+    <ClInclude Include="math\structure\Matrix4x4.h" />
+    <ClInclude Include="math\structure\Transform.h" />
+    <ClInclude Include="math\structure\Vector2.h" />
+    <ClInclude Include="math\structure\Vector3.h" />
+    <ClInclude Include="math\structure\Vector4.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/MT4.vcxproj.filters
+++ b/MT4.vcxproj.filters
@@ -14,6 +14,9 @@
     <Filter Include="KamataEngine\Adapter">
       <UniqueIdentifier>{c6468eb4-788b-4a83-b207-a5f4804e56c5}</UniqueIdentifier>
     </Filter>
+    <Filter Include="math">
+      <UniqueIdentifier>{91538361-133b-43dd-8eba-b8842bea25be}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
@@ -102,6 +105,33 @@
     </ClInclude>
     <ClInclude Include="C:\KamataEngine\DirectXGame\2d\ImGuiManager.h">
       <Filter>KamataEngine\Include</Filter>
+    </ClInclude>
+    <ClInclude Include="math\structure\Matrix3x3.h">
+      <Filter>math</Filter>
+    </ClInclude>
+    <ClInclude Include="math\MathFunc4x4.h">
+      <Filter>math</Filter>
+    </ClInclude>
+    <ClInclude Include="math\structure\Vector4.h">
+      <Filter>math</Filter>
+    </ClInclude>
+    <ClInclude Include="math\structure\Vector3.h">
+      <Filter>math</Filter>
+    </ClInclude>
+    <ClInclude Include="math\structure\Vector2.h">
+      <Filter>math</Filter>
+    </ClInclude>
+    <ClInclude Include="math\structure\Transform.h">
+      <Filter>math</Filter>
+    </ClInclude>
+    <ClInclude Include="math\RenderingMatrices.h">
+      <Filter>math</Filter>
+    </ClInclude>
+    <ClInclude Include="math\structure\Matrix4x4.h">
+      <Filter>math</Filter>
+    </ClInclude>
+    <ClInclude Include="math\AffineTransformations.h">
+      <Filter>math</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/main.cpp
+++ b/main.cpp
@@ -1,22 +1,104 @@
+/*********************************************************************
+ * \file   main.cpp
+ * \brief  
+ * 
+ * \author Harukichimaru
+ * \date   January 2025
+ * \note   
+ *********************************************************************/
 #include <Novice.h>
-
 const char kWindowTitle[] = "学籍番号";
+//========================================
+// 数学構造体関数
+#include "Vector2.h"
+#include "Vector3.h"
+#include "Vector4.h"
+#include "Matrix3x3.h"
+#include "Matrix4x4.h"
+#include "Transform.h"
+//========================================
+// 数学関数
+#include "AffineTransformations.h"
+#include "MathFunc4x4.h"
+#include "RenderingMatrices.h"
 
-// Windowsアプリでのエントリーポイント(main関数)
+///=============================================================================
+///						任意軸回転行列作成
+Matrix4x4 MakeRotateAxisMatrix(const Vector3& axis, float angle) {
+	//========================================
+	// 軸ベクトルを正規化
+	Vector3 n = Normalize(axis);
+	//========================================
+	// 角度のcos, sin, 1-cosを計算
+	float c = cosf(angle);
+	float s = sinf(angle);
+	//========================================
+	// 回転行列を計算
+	float t = 1.0f - c;
+	// 回転行列
+	Matrix4x4 m;
+	m.m[0][0] = t * n.x * n.x + c;
+	m.m[0][1] = t * n.x * n.y + s * n.z;
+	m.m[0][2] = t * n.x * n.z - s * n.y;
+	m.m[0][3] = 0.0f;
+	m.m[1][0] = t * n.x * n.y - s * n.z;
+	m.m[1][1] = t * n.y * n.y + c;
+	m.m[1][2] = t * n.y * n.z + s * n.x;
+	m.m[1][3] = 0.0f;
+	m.m[2][0] = t * n.x * n.z + s * n.y;
+	m.m[2][1] = t * n.y * n.z - s * n.x;
+	m.m[2][2] = t * n.z * n.z + c;
+	m.m[2][3] = 0.0f;
+	m.m[3][0] = 0.0f;
+	m.m[3][1] = 0.0f;
+	m.m[3][2] = 0.0f;
+	m.m[3][3] = 1.0f;
+	//========================================
+	// 計算結果を返す
+	return m;
+}
+
+///=============================================================================
+///						マトリックス出力
+void ScreenPrintMatrix(const char* name, const Matrix4x4 &m, int x, int y) {
+	Novice::ScreenPrintf(x, y, name);
+	Novice::ScreenPrintf(x, y + 20, "%.3f %.3f %.3f %.3f", m.m[0][0], m.m[0][1], m.m[0][2], m.m[0][3]);
+	Novice::ScreenPrintf(x, y + 40, "%.3f %.3f %.3f %.3f", m.m[1][0], m.m[1][1], m.m[1][2], m.m[1][3]);
+	Novice::ScreenPrintf(x, y + 60, "%.3f %.3f %.3f %.3f", m.m[2][0], m.m[2][1], m.m[2][2], m.m[2][3]);
+	Novice::ScreenPrintf(x, y + 80, "%.3f %.3f %.3f %.3f", m.m[3][0], m.m[3][1], m.m[3][2], m.m[3][3]);
+}
+
+///=============================================================================
+///	Windowsアプリでのエントリーポイント(main関数)
 int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
-
+	//========================================
 	// ライブラリの初期化
 	Novice::Initialize(kWindowTitle, 1280, 720);
-
+	//========================================
 	// キー入力結果を受け取る箱
 	char keys[256] = {0};
 	char preKeys[256] = {0};
 
-	// ウィンドウの×ボタンが押されるまでループ
+	///--------------------------------------------------------------
+	///	変数宣言
+	//========================================
+	// 任意軸回転行列
+	// 軸
+	Vector3 axis = { 1.0f, 1.0f, 1.0f };
+	// 正規化
+	axis = Normalize(axis);
+	// 角度
+	float angle = 0.44f;
+	// 行列の計算
+	Matrix4x4 rotateMatrix = MakeRotateAxisMatrix(axis, angle);
+
+	///--------------------------------------------------------------
+	/// ウィンドウの×ボタンが押されるまでループ
 	while (Novice::ProcessMessage() == 0) {
+		//========================================
 		// フレームの開始
 		Novice::BeginFrame();
-
+		//========================================
 		// キー入力を受け取る
 		memcpy(preKeys, keys, 256);
 		Novice::GetHitKeyStateAll(keys);
@@ -32,6 +114,10 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 		///
 		/// ↓描画処理ここから
 		///
+
+		//========================================
+		// 任意軸回転行列の表示
+		ScreenPrintMatrix("RotateMatrix", rotateMatrix, 10, 10);
 
 		///
 		/// ↑描画処理ここまで

--- a/math/AffineTransformations.h
+++ b/math/AffineTransformations.h
@@ -1,0 +1,138 @@
+#pragma once
+#include "structure/Vector3.h"
+#include "structure/Matrix4x4.h"
+#include "RenderingMatrices.h"
+#include "MathFunc4x4.h"
+#include <cmath>
+#include <cassert>
+
+///=====================================================/// 
+///3次元アフィン行列用関数
+///=====================================================///
+	/// <summary>
+	/// 平行移動行列を作成する関数
+	/// </summary>
+	/// <param name="translate"></param>
+	/// <returns></returns>
+inline Matrix4x4 MakeTranslateMatrix(const Vector3& translate) {
+	Matrix4x4 result = Identity4x4(); // 単位行列を初期化
+
+	// 平行移動成分をセット
+	result.m[3][0] = translate.x;
+	result.m[3][1] = translate.y;
+	result.m[3][2] = translate.z;
+
+	return result;
+}
+
+/// <summary>
+/// 拡大縮小行列を作成する関数
+/// </summary>
+/// <param name="scale"></param>
+/// <returns></returns>
+inline Matrix4x4 MakeScaleMatrix(const Vector3& scale) {
+	// 単位行列を初期化
+	Matrix4x4 result = Identity4x4();
+
+	// 拡大縮小成分をセット
+	result.m[0][0] = scale.x;
+	result.m[1][1] = scale.y;
+	result.m[2][2] = scale.z;
+
+	return result;
+}
+
+/// <summary>
+/// X軸回転行列(yz)
+/// </summary>
+/// <param name="radian"></param>
+/// <returns></returns>
+inline Matrix4x4 MakeRotateXMatrix(float radian) {
+	// 単位行列で初期化
+	Matrix4x4 result = Identity4x4();
+
+	//行列の計算
+	result.m[1][1] = std::cos(radian);
+	result.m[1][2] = std::sin(radian);
+	result.m[2][1] = -std::sin(radian);
+	result.m[2][2] = std::cos(radian);
+
+	return result;
+}
+
+/// <summary>
+/// Y軸回転行列(zx)
+/// </summary>
+/// <param name="radian"></param>
+/// <returns></returns>
+inline Matrix4x4 MakeRotateYMatrix(float radian) {
+	// 単位行列で初期化
+	Matrix4x4 result = Identity4x4();
+
+	//行列の計算
+	result.m[0][0] = std::cos(radian);
+	result.m[0][2] = -std::sin(radian);
+	result.m[2][0] = std::sin(radian);
+	result.m[2][2] = std::cos(radian);
+
+	return result;
+}
+
+/// <summary>
+/// Z軸回転行列(xy)
+/// </summary>
+/// <param name="radian"></param>
+/// <returns></returns>
+inline Matrix4x4 MakeRotateZMatrix(float radian) {
+	// 単位行列で初期化
+	Matrix4x4 result = Identity4x4();
+
+	//行列の計算
+	result.m[0][0] = std::cos(radian);
+	result.m[0][1] = std::sin(radian);
+	result.m[1][0] = -std::sin(radian);
+	result.m[1][1] = std::cos(radian);
+
+	return result;
+}
+
+/// <summary>
+/// 座標変換を行う関数
+/// </summary>
+/// <param name="vector"></param>
+/// <param name="matrix"></param>
+/// <returns></returns>
+inline Vector3 Conversion(const Vector3& vector, const Matrix4x4& matrix) {
+	Vector3 result;
+
+	// 行列とベクトルの乗算
+	result.x = vector.x * matrix.m[0][0] + vector.y * matrix.m[1][0] + vector.z * matrix.m[2][0] + matrix.m[3][0];
+	result.y = vector.x * matrix.m[0][1] + vector.y * matrix.m[1][1] + vector.z * matrix.m[2][1] + matrix.m[3][1];
+	result.z = vector.x * matrix.m[0][2] + vector.y * matrix.m[1][2] + vector.z * matrix.m[2][2] + matrix.m[3][2];
+	float w = vector.x * matrix.m[0][3] + vector.y * matrix.m[1][3] + vector.z * matrix.m[2][3] + matrix.m[3][3];
+	//この処理を忘れない！
+	assert(w != 0.0f);
+	result.x /= w;
+	result.y /= w;
+	result.z /= w;
+	return result;
+}
+
+//アフィン変換
+inline Matrix4x4 MakeAffineMatrix(const Vector3& scale, const Vector3& rotate, const Vector3& translate) {
+	//縮小拡大
+	Matrix4x4 scaleMatrix = MakeScaleMatrix(scale);
+	//回転
+	Matrix4x4 rotateXMatrix = MakeRotateXMatrix(rotate.x);
+	Matrix4x4 rotateYMatrix = MakeRotateYMatrix(rotate.y);
+	Matrix4x4 rotateZMatrix = MakeRotateZMatrix(rotate.z);
+	Matrix4x4 rotateXYZMatrix = Multiply4x4(rotateXMatrix, Multiply4x4(rotateYMatrix, rotateZMatrix));
+	//並行移動
+	Matrix4x4 translateMatrix = MakeTranslateMatrix(translate);
+	//合成
+	Matrix4x4 result = Identity4x4();
+	result = Multiply4x4(scaleMatrix, rotateXYZMatrix);
+	result = Multiply4x4(result, translateMatrix);
+
+	return result;
+}

--- a/math/MathFunc4x4.h
+++ b/math/MathFunc4x4.h
@@ -1,0 +1,227 @@
+/*********************************************************************
+ * \file   Calc4x4.h
+ * \brief  4x4行列の計算関数
+ * 
+ * \author Harukichimaru
+ * \date   November 2024
+ * \note   
+ *********************************************************************/
+//NOTE:04_02_09を見ると関数分けがわかるぞ
+
+#pragma once
+#include <stdexcept>
+#include "Matrix4x4.h"
+
+/**----------------------------------------------------------------------------
+ * \brief  Add4x4 行列の加算
+ * \param  m1 
+ * \param  m2 
+ * \return Matrix4x4
+ * \note   
+ */
+inline Matrix4x4 Add4x4(const Matrix4x4& m1, const Matrix4x4& m2) {
+	Matrix4x4 result;
+	for (int i = 0; i < 4; ++i) {
+		for (int j = 0; j < 4; ++j) {
+			result.m[i][j] = m1.m[i][j] + m2.m[i][j];
+		}
+	}
+	return result;
+}
+
+/**----------------------------------------------------------------------------
+ * \brief  Subtract4x4 行列の減算
+ * \param  m1 
+ * \param  m2 
+ * \return Matrix4x4
+ * \note   
+ */
+inline Matrix4x4 Subtract4x4(const Matrix4x4& m1, const Matrix4x4& m2) {
+	Matrix4x4 result;
+	for (int i = 0; i < 4; ++i) {
+		for (int j = 0; j < 4; ++j) {
+			result.m[i][j] = m1.m[i][j] - m2.m[i][j];
+		}
+	}
+	return result;
+}
+
+/**----------------------------------------------------------------------------
+ * \brief  Multiply4x4 行列の乗算
+ * \param  m1
+ * \param  m2
+ * \return Matrix4x4
+ * \note
+ */
+inline Matrix4x4 Multiply4x4(const Matrix4x4& m1, const Matrix4x4& m2) {
+	Matrix4x4 result;
+
+	// 行列の各成分を直接計算して結果を求める
+	result.m[0][0] = m1.m[0][0] * m2.m[0][0] + m1.m[0][1] * m2.m[1][0] + m1.m[0][2] * m2.m[2][0] + m1.m[0][3] * m2.m[3][0];
+	result.m[0][1] = m1.m[0][0] * m2.m[0][1] + m1.m[0][1] * m2.m[1][1] + m1.m[0][2] * m2.m[2][1] + m1.m[0][3] * m2.m[3][1];
+	result.m[0][2] = m1.m[0][0] * m2.m[0][2] + m1.m[0][1] * m2.m[1][2] + m1.m[0][2] * m2.m[2][2] + m1.m[0][3] * m2.m[3][2];
+	result.m[0][3] = m1.m[0][0] * m2.m[0][3] + m1.m[0][1] * m2.m[1][3] + m1.m[0][2] * m2.m[2][3] + m1.m[0][3] * m2.m[3][3];
+
+	result.m[1][0] = m1.m[1][0] * m2.m[0][0] + m1.m[1][1] * m2.m[1][0] + m1.m[1][2] * m2.m[2][0] + m1.m[1][3] * m2.m[3][0];
+	result.m[1][1] = m1.m[1][0] * m2.m[0][1] + m1.m[1][1] * m2.m[1][1] + m1.m[1][2] * m2.m[2][1] + m1.m[1][3] * m2.m[3][1];
+	result.m[1][2] = m1.m[1][0] * m2.m[0][2] + m1.m[1][1] * m2.m[1][2] + m1.m[1][2] * m2.m[2][2] + m1.m[1][3] * m2.m[3][2];
+	result.m[1][3] = m1.m[1][0] * m2.m[0][3] + m1.m[1][1] * m2.m[1][3] + m1.m[1][2] * m2.m[2][3] + m1.m[1][3] * m2.m[3][3];
+
+	result.m[2][0] = m1.m[2][0] * m2.m[0][0] + m1.m[2][1] * m2.m[1][0] + m1.m[2][2] * m2.m[2][0] + m1.m[2][3] * m2.m[3][0];
+	result.m[2][1] = m1.m[2][0] * m2.m[0][1] + m1.m[2][1] * m2.m[1][1] + m1.m[2][2] * m2.m[2][1] + m1.m[2][3] * m2.m[3][1];
+	result.m[2][2] = m1.m[2][0] * m2.m[0][2] + m1.m[2][1] * m2.m[1][2] + m1.m[2][2] * m2.m[2][2] + m1.m[2][3] * m2.m[3][2];
+	result.m[2][3] = m1.m[2][0] * m2.m[0][3] + m1.m[2][1] * m2.m[1][3] + m1.m[2][2] * m2.m[2][3] + m1.m[2][3] * m2.m[3][3];
+
+	result.m[3][0] = m1.m[3][0] * m2.m[0][0] + m1.m[3][1] * m2.m[1][0] + m1.m[3][2] * m2.m[2][0] + m1.m[3][3] * m2.m[3][0];
+	result.m[3][1] = m1.m[3][0] * m2.m[0][1] + m1.m[3][1] * m2.m[1][1] + m1.m[3][2] * m2.m[2][1] + m1.m[3][3] * m2.m[3][1];
+	result.m[3][2] = m1.m[3][0] * m2.m[0][2] + m1.m[3][1] * m2.m[1][2] + m1.m[3][2] * m2.m[2][2] + m1.m[3][3] * m2.m[3][2];
+	result.m[3][3] = m1.m[3][0] * m2.m[0][3] + m1.m[3][1] * m2.m[1][3] + m1.m[3][2] * m2.m[2][3] + m1.m[3][3] * m2.m[3][3];
+
+	return result;
+}
+
+
+// 余因子行列の計算に必要なサブ行列を計算するヘルパー関数
+inline Matrix4x4 Cofactor4x4(const Matrix4x4& matrix);
+
+// 余因子行列の計算に必要な小行列式を計算するヘルパー関数
+inline float Minor(const Matrix4x4& matrix, int row, int col);
+
+/**----------------------------------------------------------------------------
+ * \brief  Inverse4x4 逆行列を求める
+ * \param  matrix 
+ * \return Matrix4x4
+ * \note   
+ */
+inline Matrix4x4 Inverse4x4(const Matrix4x4& matrix) {
+	// 行列式を計算
+	float det =
+		matrix.m[0][0] * ( matrix.m[1][1] * matrix.m[2][2] * matrix.m[3][3] +
+			matrix.m[1][2] * matrix.m[2][3] * matrix.m[3][1] +
+			matrix.m[1][3] * matrix.m[2][1] * matrix.m[3][2] -
+			matrix.m[1][3] * matrix.m[2][2] * matrix.m[3][1] -
+			matrix.m[1][1] * matrix.m[2][3] * matrix.m[3][2] -
+			matrix.m[1][2] * matrix.m[2][1] * matrix.m[3][3] ) -
+		matrix.m[0][1] * ( matrix.m[1][0] * matrix.m[2][2] * matrix.m[3][3] +
+			matrix.m[1][2] * matrix.m[2][3] * matrix.m[3][0] +
+			matrix.m[1][3] * matrix.m[2][0] * matrix.m[3][2] -
+			matrix.m[1][3] * matrix.m[2][2] * matrix.m[3][0] -
+			matrix.m[1][0] * matrix.m[2][3] * matrix.m[3][2] -
+			matrix.m[1][2] * matrix.m[2][0] * matrix.m[3][3] ) +
+		matrix.m[0][2] * ( matrix.m[1][0] * matrix.m[2][1] * matrix.m[3][3] +
+			matrix.m[1][1] * matrix.m[2][3] * matrix.m[3][0] +
+			matrix.m[1][3] * matrix.m[2][0] * matrix.m[3][1] -
+			matrix.m[1][3] * matrix.m[2][1] * matrix.m[3][0] -
+			matrix.m[1][0] * matrix.m[2][3] * matrix.m[3][1] -
+			matrix.m[1][1] * matrix.m[2][0] * matrix.m[3][3] ) -
+		matrix.m[0][3] * ( matrix.m[1][0] * matrix.m[2][1] * matrix.m[3][2] +
+			matrix.m[1][1] * matrix.m[2][2] * matrix.m[3][0] +
+			matrix.m[1][2] * matrix.m[2][0] * matrix.m[3][1] -
+			matrix.m[1][2] * matrix.m[2][1] * matrix.m[3][0] -
+			matrix.m[1][0] * matrix.m[2][2] * matrix.m[3][1] -
+			matrix.m[1][1] * matrix.m[2][0] * matrix.m[3][2] );
+
+	// 行列式が0の場合は逆行列は存在しない
+	if (det == 0) {
+		throw std::runtime_error("Matrix is singular and cannot be inverted.");
+	}
+
+	Matrix4x4 cofactorMatrix = Cofactor4x4(matrix);
+	Matrix4x4 adjugateMatrix;
+	// 余因子行列の転置を求める
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			adjugateMatrix.m[i][j] = cofactorMatrix.m[j][i];
+		}
+	}
+
+	Matrix4x4 inverseMatrix;
+	// 逆行列を求める
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			inverseMatrix.m[i][j] = adjugateMatrix.m[i][j] / det;
+		}
+	}
+
+	return inverseMatrix;
+}
+
+/**----------------------------------------------------------------------------
+ * \brief  Cofactor4x4 余因子行列を求める
+ * \param  matrix
+ * \return 
+ * \note   
+ */
+inline Matrix4x4 Cofactor4x4(const Matrix4x4& matrix) {
+	Matrix4x4 cofactorMatrix;
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			float minor = Minor(matrix, i, j);
+			// 余因子行列の符号付き小行列行列式
+			cofactorMatrix.m[i][j] = ( ( i + j ) % 2 == 0 ? 1 : -1 ) * minor;
+		}
+	}
+	return cofactorMatrix;
+}
+
+/**----------------------------------------------------------------------------
+ * \brief  Minor 小行列式を求める
+ * \param  matrix
+ * \param  row
+ * \param  col
+ * \return 
+ * \note   
+ */
+inline float Minor(const Matrix4x4& matrix, int row, int col) {
+	float subMatrix[3][3];
+	int subRow = 0;
+	for (int i = 0; i < 4; i++) {
+		if (i == row) continue;
+		int subCol = 0;
+		for (int j = 0; j < 4; j++) {
+			if (j == col) continue;
+			subMatrix[subRow][subCol] = matrix.m[i][j];
+			subCol++;
+		}
+		subRow++;
+	}
+
+	return subMatrix[0][0] * ( subMatrix[1][1] * subMatrix[2][2] - subMatrix[1][2] * subMatrix[2][1] ) -
+		subMatrix[0][1] * ( subMatrix[1][0] * subMatrix[2][2] - subMatrix[1][2] * subMatrix[2][0] ) +
+		subMatrix[0][2] * ( subMatrix[1][0] * subMatrix[2][1] - subMatrix[1][1] * subMatrix[2][0] );
+}
+
+/**----------------------------------------------------------------------------
+ * \brief  Transpose4x4 転置行列を求める
+ * \param  matrix
+ * \return 
+ * \note   
+ */
+inline Matrix4x4 Transpose4x4(const Matrix4x4& matrix) {
+	Matrix4x4 result;
+	for (int i = 0; i < 4; ++i) {
+		for (int j = 0; j < 4; ++j) {
+			result.m[i][j] = matrix.m[j][i];
+		}
+	}
+	return result;
+}
+
+/**----------------------------------------------------------------------------
+ * \brief  Identity4x4 単位行列を生成する
+ * \return 
+ * \note   
+ */
+inline Matrix4x4 Identity4x4() {
+	Matrix4x4 result;
+	for (int i = 0; i < 4; ++i) {
+		for (int j = 0; j < 4; ++j) {
+			if (i == j) {
+				result.m[i][j] = 1.0f;
+			} else {
+				result.m[i][j] = 0.0f;
+			}
+		}
+	}
+	return result;
+}

--- a/math/RenderingMatrices.h
+++ b/math/RenderingMatrices.h
@@ -1,0 +1,83 @@
+#pragma once
+#include"Matrix4x4.h"
+#include"AffineTransformations.h"
+#include "MathFunc4x4.h"
+#include <cmath>
+
+/// <summary>
+/// 正射影行列
+/// </summary>
+/// <param name="left"></param>
+/// <param name="top"></param>
+/// <param name="right"></param>
+/// <param name="bottom"></param>
+/// <param name="nearClip"></param>
+/// <param name="farClip"></param>
+/// <returns></returns>
+inline Matrix4x4 MakeOrthographicMatrix(float left, float top, float right, float bottom, float nearClip, float farClip) {
+	// 単位行列で初期化
+	Matrix4x4 result = Identity4x4();
+
+	// 正射影平面の範囲から正射影行列を構築する
+	result.m[0][0] = 2.0f / ( right - left );
+	result.m[1][1] = 2.0f / ( top - bottom );
+	result.m[2][2] = -2.0f / ( farClip - nearClip );
+	result.m[3][0] = -( right + left ) / ( right - left );
+	result.m[3][1] = -( top + bottom ) / ( top - bottom );
+	result.m[3][2] = -( farClip + nearClip ) / ( farClip - nearClip );
+
+	return result;
+
+}
+
+/// <summary>
+/// 透視投影行列
+/// </summary>
+/// <param name="fovY"></param>
+/// <param name="aspectRatio"></param>
+/// <param name="nearClip"></param>
+/// <param name="farClip"></param>
+/// <returns></returns>
+inline Matrix4x4 MakePerspectiveFovMatrix(float fovY, float aspectRatio, float nearClip, float farClip) {
+	// 単位行列で初期化
+	Matrix4x4 result = Identity4x4();
+
+	// tanの逆説
+	float cot = tanf(fovY / 2.0f);
+
+	// 射影変換行列の要素を計算する
+	result.m[0][0] = 1.0f / ( aspectRatio * cot );
+	result.m[1][1] = 1.0f / cot;
+	result.m[2][2] = farClip / ( farClip - nearClip );
+	result.m[2][3] = 1.0f;
+	result.m[3][2] = -nearClip * farClip / ( farClip - nearClip );
+	result.m[3][3] = 0.0f;
+
+	return result;
+}
+
+/// <summary>
+/// ビューポート行列
+/// </summary>
+/// <param name="left"></param>
+/// <param name="top"></param>
+/// <param name="width"></param>
+/// <param name="height"></param>
+/// <param name="minDepth"></param>
+/// <param name="maxDepth"></param>
+/// <returns></returns>
+inline Matrix4x4 MakeViewportMatrix(float left, float top, float width, float height, float minDepth, float maxDepth) {
+	// 単位行列で初期化
+	Matrix4x4 result = Identity4x4();
+
+	// ビューポート変換行列の要素を計算する
+	result.m[0][0] = width / 2.0f;
+	result.m[1][1] = -height / 2.0f;
+	result.m[2][2] = maxDepth - minDepth;
+	result.m[3][0] = left + width / 2.0f;
+	result.m[3][1] = top + height / 2.0f;
+	result.m[3][2] = minDepth;
+
+	return result;
+}
+

--- a/math/structure/Matrix3x3.h
+++ b/math/structure/Matrix3x3.h
@@ -1,0 +1,7 @@
+#pragma once
+/// <summary>
+/// 3x3行列
+/// </summary>
+struct Matrix3x3 final {
+	float m[3][3];
+};

--- a/math/structure/Matrix4x4.h
+++ b/math/structure/Matrix4x4.h
@@ -1,0 +1,72 @@
+#pragma once
+#include <iostream>
+
+/// <summary>
+/// 4x4行列
+/// </summary>
+struct Matrix4x4 {
+    float m[4][4];
+
+    // 行列の加算
+    Matrix4x4 operator+(const Matrix4x4& other) const {
+        Matrix4x4 result;
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                result.m[i][j] = this->m[i][j] + other.m[i][j];
+            }
+        }
+        return result;
+    }
+
+    // 行列の減算
+    Matrix4x4 operator-(const Matrix4x4& other) const {
+        Matrix4x4 result;
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                result.m[i][j] = this->m[i][j] - other.m[i][j];
+            }
+        }
+        return result;
+    }
+
+    // 行列の乗算
+    Matrix4x4 operator*(const Matrix4x4& other) const {
+        Matrix4x4 result = {};
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                for (int k = 0; k < 4; ++k) {
+                    result.m[i][j] += this->m[i][k] * other.m[k][j];
+                }
+            }
+        }
+        return result;
+    }
+
+    // 行列のスカラー乗算
+    Matrix4x4 operator*(float scalar) const {
+        Matrix4x4 result;
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                result.m[i][j] = this->m[i][j] * scalar;
+            }
+        }
+        return result;
+    }
+
+    // 行列の等価比較
+    bool operator==(const Matrix4x4& other) const {
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                if (this->m[i][j] != other.m[i][j]) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    // 行列の非等価比較
+    bool operator!=(const Matrix4x4& other) const {
+        return !(*this == other);
+    }
+};

--- a/math/structure/Transform.h
+++ b/math/structure/Transform.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "Vector3.h"
+
+struct Transform {
+	Vector3 scale;
+	Vector3 rotate;
+	Vector3 translate;
+};

--- a/math/structure/Vector2.h
+++ b/math/structure/Vector2.h
@@ -1,0 +1,9 @@
+#pragma once
+
+/// <summary>
+/// 2次元ベクトル
+/// </summary>
+const struct Vector2 {
+	float x;
+	float y;
+};

--- a/math/structure/Vector3.h
+++ b/math/structure/Vector3.h
@@ -1,0 +1,76 @@
+#pragma once
+#include <cmath>
+
+/// <summary>
+/// 3次元ベクトル
+/// </summary>
+struct Vector3 final{
+	float x;
+	float y;
+	float z;
+
+	// 加算演算子
+	Vector3 operator+(const Vector3& other) const {
+		return { x + other.x, y + other.y, z + other.z };
+	}
+
+	// 減算演算子
+	Vector3 operator-(const Vector3& other) const {
+		return { x - other.x, y - other.y, z - other.z };
+	}
+
+	// スカラー乗算演算子
+	Vector3 operator*(float scalar) const {
+		return { x * scalar, y * scalar, z * scalar };
+	}
+
+	// スカラー除算演算子
+	Vector3 operator/(float scalar) const {
+		return { x / scalar, y / scalar, z / scalar };
+	}
+
+	// 等価演算子
+	bool operator==(const Vector3& other) const {
+		return x == other.x && y == other.y && z == other.z;
+	}
+
+	// 非等価演算子
+	bool operator!=(const Vector3& other) const {
+		return !(*this == other);
+	}
+};
+
+// 内積
+inline float Dot(const Vector3& v1, const Vector3& v2) {
+	return v1.x * v2.x + v1.y * v2.y + v1.z * v2.z;
+}
+
+// ベクトルの大きさ（長さ）を計算する関数
+inline float Magnitude(const Vector3& v) {
+	return std::sqrt(Dot(v, v));
+}
+
+// ベクトルを正規化
+inline Vector3 Normalize(const Vector3& v) {
+	float mag = Magnitude(v);
+	if(mag != 0.0f) {
+		return { v.x / mag, v.y / mag, v.z / mag };
+	}
+	// ゼロベクトルの場合はそのまま返す
+	return v;
+}
+
+inline Vector3 AddVec3(const Vector3& v1, const Vector3& v2) {
+	return { v1.x + v2.x, v1.y + v2.y, v1.z + v2.z };
+}
+
+inline Vector3 MultiplyVec3(float scalar, const Vector3& v) {
+	return { scalar * v.x, scalar * v.y, scalar * v.z };
+}
+
+// ベクトルの長さを計算する関数
+inline float Length(const Vector3& v) { return std::sqrt(Dot(v, v)); }
+
+// 2つのベクトル間の距離を計算する関数
+inline float Distance(const Vector3& v1, const Vector3& v2) { return Length(v1 - v2); }
+

--- a/math/structure/Vector4.h
+++ b/math/structure/Vector4.h
@@ -1,0 +1,11 @@
+#pragma once
+
+/// <summary>
+/// 4次元ベクトル
+/// </summary>
+struct Vector4 {
+	float x;
+	float y;
+	float z;
+	float w;
+};


### PR DESCRIPTION
`MT4.vcxproj` と `MT4.vcxproj.filters` に新しいインクルードディレクトリとフィルターを追加し、`main.cpp` に数学関数の実装と表示を追加しました。また、新しいヘッダーファイル `AffineTransformations.h` を追加し、3次元アフィン行列用の関数を定義しました。

* `MT4.vcxproj` の変更:
  * `<AdditionalIncludeDirectories>` に `$(ProjectDir)math` と `$(ProjectDir)math/structure` を追加。
  * `<ClInclude>` に `math` ディレクトリ内の複数のヘッダーファイルを追加。

* `MT4.vcxproj.filters` の変更:
  * `math` フィルターを追加し、その中に `math` ディレクトリ内の複数のヘッダーファイルを追加。

* `main.cpp` の変更:
  * ファイルの冒頭にファイル情報のコメントを追加。
  * 数学構造体関数と数学関数のヘッダーファイルをインクルード。
  * `MakeRotateAxisMatrix` 関数を追加。
  * `ScreenPrintMatrix` 関数を追加。
  * `WinMain` 関数内で任意軸回転行列の計算と表示を追加。

* `AffineTransformations.h` の変更:
  * 新規ファイルとして追加。
  * 3次元アフィン行列用の関数を定義。
  * 平行移動行列、拡大縮小行列、X軸回転行列、Y軸回転行列、Z軸回転行列、座標変換関数、アフィン変換行列作成関数を追加。

* `MathFunc4x4.h` に新しい関数が追加されました。これには、4x4行列の加算、減算、乗算、逆行列、余因子行列、小行列式、転置行列、単位行列を生成する関数が含まれます。また、ファイルのヘッダーコメントも追加されました。
* `RenderingMatrices.h` に新しい関数が追加されました。これには、正射影行列、透視投影行列、ビューポート行列を生成する関数が含まれます。
* `Matrix3x3.h` に3x3行列を表す構造体 `Matrix3x3` が追加されました。
* `Matrix4x4.h` に4x4行列を表す構造体 `Matrix4x4` が追加されました。この構造体には、行列の加算、減算、乗算、スカラー乗算、等価比較、非等価比較の演算子オーバーロードが含まれます。
* `Transform.h` に `Transform` 構造体が追加されました。この構造体は、スケール、回転、平行移動を表す `Vector3` を含みます。
* `Vector2.h` に2次元ベクトルを表す構造体 `Vector2` が追加されました。
* `Vector3.h` に3次元ベクトルを表す構造体 `Vector3` が追加されました。この構造体には、加算、減算、スカラー乗算、スカラー除算、等価比較、非等価比較の演算子オーバーロードが含まれます。また、内積、ベクトルの大きさ、正規化、ベクトルの加算、スカラー乗算、ベクトルの長さ、2つのベクトル間の距離を計算する関数が追加されました。
* `Vector4.h` に4次元ベクトルを表す構造体 `Vector4` が追加されました。